### PR TITLE
Probably better fix of setting home position

### DIFF
--- a/working_villagers/building.lua
+++ b/working_villagers/building.lua
@@ -454,6 +454,6 @@ function working_villages.home:get_bed()
 end
 
 -- set the home of a villager
-function working_villages.set_home(inv_name,marker_pos)
-	working_villages.homes[inv_name] = working_villages.home:new{marker = marker_pos}
+function working_villages.set_home(self, marker_pos)
+	working_villages.homes[self.inventory_name] = working_villages.home:new{marker = marker_pos}
 end

--- a/working_villagers/forms.lua
+++ b/working_villagers/forms.lua
@@ -283,7 +283,7 @@ forms.register_page("working_villages:inv_gui", {
 			return
 		end
 
-		villager.set_home(villager.inventory_name,coords)
+		villager:set_home(coords)
 		minetest.chat_send_player(sender_name, 'Home set!')
 		if minetest.get_meta(coords):get_string("valid") == "false" then
 			minetest.chat_send_player(sender_name, 'Home marker not configured, '..


### PR DESCRIPTION
Uses self.inventory_name instead of inv_name from parameter in function working_villages.set_home, use object method call in form.lua, villager:set_home(coords).