### PR TITLE
Add spawning of self-employed villagers

### DIFF
--- a/working_villagers/api.lua
+++ b/working_villagers/api.lua
@@ -847,7 +847,7 @@ function working_villages.register_villager(product_name, def)
       working_villages.manufacturing_data[name] = working_villages.manufacturing_data[name] + 1
       local inventory = create_inventory(self)
 
-      if self.object:get_luaentity().owner_name == "" then
+      if self.object:get_luaentity().owner_name == "working_villages:self_employed" then
         -- Spawned in with no owner, assign job
         local job_stack = ItemStack("working_villages:job_herbcollector")
         inventory:set_stack("job", 1, job_stack)
@@ -953,7 +953,8 @@ function working_villages.register_villager(product_name, def)
   local function on_rightclick(self, clicker)
     local wielded_stack = clicker:get_wielded_item()
     if wielded_stack:get_name() == "working_villages:commanding_sceptre"
-      and clicker:get_player_name() == self.owner_name then
+      and (self.owner_name == "working_villages:self_employed"
+        or clicker:get_player_name() == self.owner_name) then
 
       forms.show_formspec(self, "working_villages:inv_gui", clicker:get_player_name())
     else

--- a/working_villagers/api.lua
+++ b/working_villagers/api.lua
@@ -851,8 +851,9 @@ function working_villages.register_villager(product_name, def)
       working_villages.manufacturing_data[name] = working_villages.manufacturing_data[name] + 1
       local inventory = create_inventory(self)
 
-      if not self:get_luaentity().owner_name then
+      if self.object:get_luaentity().owner_name == "" then
         -- Spawned in with no owner, assign job
+        minetest.log("action", "Setting initial job.")
         local job_stack = ItemStack("working_villages:job_herbcollector")
         inventory:set_stack("job", 1, job_stack)
       end
@@ -894,6 +895,7 @@ function working_villages.register_villager(product_name, def)
 
     local job = self:get_job()
     if job ~= nil then
+      minetest.log("action", "Found job "..dump(job))
       if type(job.on_start)=="function" then
         job.on_start(self)
         self.job_thread = coroutine.create(job.on_step)

--- a/working_villagers/api.lua
+++ b/working_villagers/api.lua
@@ -389,7 +389,6 @@ function working_villages.villager:update_infotext()
     infotext = infotext .. ", [paused]"
   end
   self.object:set_properties{infotext = infotext}
-  minetest.log("action", "Updated infotext "..infotext)
 end
 
 -- working_villages.villager.is_near checks if the villager is within the radius of a position
@@ -531,7 +530,6 @@ end
 
 -- working_villages.villager:new returns a new villager object.
 function working_villages.villager:new(o)
-  minetest.log("action", "new("..dump(o)..")")
   return setmetatable(o or {}, {__index = self})
 end
 
@@ -562,7 +560,6 @@ working_villages.require("async_actions")
 
 --deprecated
 function working_villages.villager:set_state(id)
-  minetest.log("action", "set_state("..dump(id)..")")
   if id == "idle" then
     print("the idle state is deprecated")
   elseif id == "goto_dest" then
@@ -845,7 +842,6 @@ function working_villages.register_villager(product_name, def)
   local function on_activate(self, staticdata)
     -- parse the staticdata, and compose a inventory.
     if staticdata == "" then
-      minetest.log("action", "on_activate()"..(working_villages.manufacturing_data[name] + 1))
       self.product_name = name
       self.manufacturing_number = working_villages.manufacturing_data[name]
       working_villages.manufacturing_data[name] = working_villages.manufacturing_data[name] + 1
@@ -853,7 +849,6 @@ function working_villages.register_villager(product_name, def)
 
       if self.object:get_luaentity().owner_name == "" then
         -- Spawned in with no owner, assign job
-        minetest.log("action", "Setting initial job.")
         local job_stack = ItemStack("working_villages:job_herbcollector")
         inventory:set_stack("job", 1, job_stack)
       end
@@ -861,7 +856,6 @@ function working_villages.register_villager(product_name, def)
       -- attach dummy item to new villager.
       minetest.add_entity(self.object:get_pos(), "working_villages:dummy_item")
     else
-      minetest.log("action", "on_activate("..staticdata..")")
       -- if static data is not empty string, this object has beed already created.
       local data = minetest.deserialize(staticdata)
 
@@ -895,7 +889,6 @@ function working_villages.register_villager(product_name, def)
 
     local job = self:get_job()
     if job ~= nil then
-      minetest.log("action", "Found job "..dump(job))
       if type(job.on_start)=="function" then
         job.on_start(self)
         self.job_thread = coroutine.create(job.on_step)

--- a/working_villagers/api.lua
+++ b/working_villagers/api.lua
@@ -389,6 +389,7 @@ function working_villages.villager:update_infotext()
     infotext = infotext .. ", [paused]"
   end
   self.object:set_properties{infotext = infotext}
+  minetest.log("action", "Updated infotext "..infotext)
 end
 
 -- working_villages.villager.is_near checks if the villager is within the radius of a position
@@ -530,6 +531,7 @@ end
 
 -- working_villages.villager:new returns a new villager object.
 function working_villages.villager:new(o)
+  minetest.log("action", "new("..dump(o)..")")
   return setmetatable(o or {}, {__index = self})
 end
 
@@ -560,6 +562,7 @@ working_villages.require("async_actions")
 
 --deprecated
 function working_villages.villager:set_state(id)
+  minetest.log("action", "set_state("..dump(id)..")")
   if id == "idle" then
     print("the idle state is deprecated")
   elseif id == "goto_dest" then
@@ -842,14 +845,22 @@ function working_villages.register_villager(product_name, def)
   local function on_activate(self, staticdata)
     -- parse the staticdata, and compose a inventory.
     if staticdata == "" then
+      minetest.log("action", "on_activate()"..(working_villages.manufacturing_data[name] + 1))
       self.product_name = name
       self.manufacturing_number = working_villages.manufacturing_data[name]
       working_villages.manufacturing_data[name] = working_villages.manufacturing_data[name] + 1
-      create_inventory(self)
+      local inventory = create_inventory(self)
+
+      if not self:get_luaentity().owner_name then
+        -- Spawned in with no owner, assign job
+        local job_stack = ItemStack("working_villages:job_herbcollector")
+        inventory:set_stack("job", 1, job_stack)
+      end
 
       -- attach dummy item to new villager.
       minetest.add_entity(self.object:get_pos(), "working_villages:dummy_item")
     else
+      minetest.log("action", "on_activate("..staticdata..")")
       -- if static data is not empty string, this object has beed already created.
       local data = minetest.deserialize(staticdata)
 

--- a/working_villagers/init.lua
+++ b/working_villagers/init.lua
@@ -51,7 +51,9 @@ working_villages.require("jobs/woodcutter")
 working_villages.require("jobs/torcher")
 working_villages.require("jobs/snowclearer")
 
-working_villages.require("spawn")
+if working_villages.setting_enabled("spawn",false) then
+  working_villages.require("spawn")
+end
 
 if working_villages.setting_enabled("debug_tools",false) then
   working_villages.require("util_test")
@@ -60,3 +62,4 @@ end
 --ready
 local time_to_load= os.clock() - init
 log.action("loaded init in %.4f s", time_to_load)
+

--- a/working_villagers/init.lua
+++ b/working_villagers/init.lua
@@ -51,6 +51,8 @@ working_villages.require("jobs/woodcutter")
 working_villages.require("jobs/torcher")
 working_villages.require("jobs/snowclearer")
 
+working_villages.require("spawn")
+
 if working_villages.setting_enabled("debug_tools",false) then
   working_villages.require("util_test")
 end

--- a/working_villagers/init.lua
+++ b/working_villagers/init.lua
@@ -5,7 +5,7 @@ working_villages={
 	modpath = minetest.get_modpath("working_villages"),
 }
 
-if not modutil then
+if not rawget(_G, "modutil") then
     dofile(working_villages.modpath.."/modutil/portable.lua")
 end
 

--- a/working_villagers/jobs/plant_collector.lua
+++ b/working_villagers/jobs/plant_collector.lua
@@ -86,7 +86,7 @@ working_villages.register_job("working_villages:job_herbcollector", {
 				self:go_to(destination)
         local herb_data = herbs.get_herb(minetest.get_node(target).name);
 				self:dig(target,true)
-        if herb_data.replant then
+        if herb_data and herb_data.replant then
           for index, value in ipairs(herb_data.replant) do
 				    self:place(value, target)
           end

--- a/working_villagers/settingtypes.txt
+++ b/working_villagers/settingtypes.txt
@@ -9,3 +9,10 @@ working_villages_enable_debug_tools (debug tools) bool false
 #    This may have a small effect on the performance.
 #    It helps finding bugs within working villages and within mods using working villages.
 working_villages_enable_debug_checks (debug checks) bool true
+
+[spawning]
+
+#    Enables spawning self-employed working villagers. The villagers that
+#    spawn in will interact with any player who has a command sceptre.
+working_villages_enable_spawn (spawn working villagers) bool false
+

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -9,7 +9,7 @@ for name,_ in pairs(working_villages.herbs.groups) do
 end
 
 local function spawn(pos, node, active_object_count, active_object_count_wider)
-    if active_object_count_wider > 2 then return end
+    if active_object_count_wider > 1 then return end
         local pos1 = {x=pos.x-4,y=pos.y-8,z=pos.z-4}
         local pos2 = {x=pos.x+4,y=pos.y+1,z=pos.z+4}
     local spawn_pos
@@ -37,7 +37,7 @@ minetest.register_abm({
     nodenames = herb_names,
     neighbors = "air",
     interval = 180,
-    chance = 1000,
+    chance = 1024,
     catch_up = false,
     action = spawn,
 })

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -38,8 +38,8 @@ minetest.register_abm({
     label = "Spawn herb collector",
     nodenames = herb_names,
     neighbors = "air",
-    interval = 18,
-    chance = 100,
+    interval = 180,
+    chance = 1000,
     catch_up = false,
     action = spawn,
 })

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -28,13 +28,6 @@ local function spawn(pos, node, active_object_count, active_object_count_wider)
             local self = minetest.add_entity(
                 {x=pos.x,y=pos.y+1,z=pos.z},gender[math.random(2)], ""
             )
-            local inv = self:get_inventory()
-            minetest.log("action", "Making "..dump(self).." with inventory "..dump(inv))
-            if not inv then return end
-            local job = working_villages.job_inv:remove_item(
-                "main","working_villages:job_herbcollector"
-            ) 
-            inv:set_stack("job", 1, job)
             minetest.log("action", "working_villages spawned at "..minetest.pos_to_string(pos,0))
             return
         end

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -22,9 +22,11 @@ local function spawn(pos, node, active_object_count, active_object_count_wider)
                 "working_villages:villager_male",
                 "working_villages:villager_female",
             }
-            local self = minetest.add_entity(
+            local new_villager = minetest.add_entity(
                 {x=pos.x,y=pos.y+1,z=pos.z},gender[math.random(2)], ""
             )
+            new_villager:get_luaentity().owner_name = "working_villages:self_employed"
+            new_villager:get_luaentity():update_infotext()
             return
         end
     end

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -17,20 +17,22 @@ local function spawn(pos, node, active_object_count, active_object_count_wider)
             pos1,pos2,{"groups:walkable"})) do
         local above = minetest.get_node({x=pos.x,y=pos.y+2,z=pos.z})
         local above_def = minetest.registered_nodes[above.name] 
-                if above_def and above_def.groups.walkable then
-            spawn_pos = pos
-            goto found
+        if above_def and above_def.groups.walkable then
+            local gender = {
+                "working_villages:villager_male",
+                "working_villages:villager_female",
+            }
+            local self = minetest.add_entity(
+                {x=pos.x,y=pos.y+1,z=pos.z},gender[math.random(2)]
+            )
+            local inv = self:get_inventory()
+            local job = working_villages.job_inv:remove_item(
+                "main","working_villages:job_herbcollector"
+            ) 
+            inv:set_stack("job", 1, job)
+            return
         end
     end
-    return
-
-    ::found::
-    local gender = {"working_villages:villager_male","working_villages:villager_female"}[math.random(2)]
-    local self = minetest.add_entity(spawn_pos,gender)
-    local inv = self:get_inventory()
-    local job = working_villages.job_inv:remove_item(
-        "main","working_villages:job_herbcollector") 
-    inv:set_stack("job", 1, job)
 end
 
 minetest.register_abm({

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -9,15 +9,12 @@ for name,_ in pairs(working_villages.herbs.groups) do
 end
 
 local function spawn(pos, node, active_object_count, active_object_count_wider)
-    minetest.log("action", "Active objects "..active_object_count_wider)
     if active_object_count_wider > 2 then return end
         local pos1 = {x=pos.x-4,y=pos.y-8,z=pos.z-4}
         local pos2 = {x=pos.x+4,y=pos.y+1,z=pos.z+4}
     local spawn_pos
-    minetest.log("action", "Search from "..minetest.pos_to_string(pos1,0).." to "..minetest.pos_to_string(pos2,0))
     for _,pos in ipairs(minetest.find_nodes_in_area_under_air(
             pos1,pos2,"group:soil")) do
-        minetest.log("action", "Considering "..minetest.pos_to_string(pos,0))
         local above = minetest.get_node({x=pos.x,y=pos.y+2,z=pos.z})
         local above_def = minetest.registered_nodes[above.name] 
         if above_def and not above_def.groups.walkable then
@@ -28,7 +25,6 @@ local function spawn(pos, node, active_object_count, active_object_count_wider)
             local self = minetest.add_entity(
                 {x=pos.x,y=pos.y+1,z=pos.z},gender[math.random(2)], ""
             )
-            minetest.log("action", "working_villages spawned at "..minetest.pos_to_string(pos,0))
             return
         end
     end

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -5,31 +5,37 @@ for name,_ in pairs(working_villages.herbs.names) do
     herb_names[#herb_names + 1] = name
 end
 for name,_ in pairs(working_villages.herbs.groups) do
-    herb_names[#herb_names + 1] = name
+    herb_names[#herb_names + 1] = "group:"..name
 end
 
 local function spawn(pos, node, active_object_count, active_object_count_wider)
+    minetest.log("action", "Active objects "..active_object_count_wider)
     if active_object_count_wider > 2 then return end
         local pos1 = {x=pos.x-4,y=pos.y-8,z=pos.z-4}
         local pos2 = {x=pos.x+4,y=pos.y+1,z=pos.z+4}
     local spawn_pos
-    for i,pos in ipairs(minetest.find_nodes_in_area_under_air(
-            pos1,pos2,{"groups:walkable"})) do
+    minetest.log("action", "Search from "..minetest.pos_to_string(pos1,0).." to "..minetest.pos_to_string(pos2,0))
+    for _,pos in ipairs(minetest.find_nodes_in_area_under_air(
+            pos1,pos2,"group:soil")) do
+        minetest.log("action", "Considering "..minetest.pos_to_string(pos,0))
         local above = minetest.get_node({x=pos.x,y=pos.y+2,z=pos.z})
         local above_def = minetest.registered_nodes[above.name] 
-        if above_def and above_def.groups.walkable then
+        if above_def and not above_def.groups.walkable then
             local gender = {
                 "working_villages:villager_male",
                 "working_villages:villager_female",
             }
             local self = minetest.add_entity(
-                {x=pos.x,y=pos.y+1,z=pos.z},gender[math.random(2)]
+                {x=pos.x,y=pos.y+1,z=pos.z},gender[math.random(2)], ""
             )
             local inv = self:get_inventory()
+            minetest.log("action", "Making "..dump(self).." with inventory "..dump(inv))
+            if not inv then return end
             local job = working_villages.job_inv:remove_item(
                 "main","working_villages:job_herbcollector"
             ) 
             inv:set_stack("job", 1, job)
+            minetest.log("action", "working_villages spawned at "..minetest.pos_to_string(pos,0))
             return
         end
     end
@@ -39,8 +45,8 @@ minetest.register_abm({
     label = "Spawn herb collector",
     nodenames = herb_names,
     neighbors = "air",
-    interval = 180,
-    chance = 1000,
-    catch_up =false,
+    interval = 18,
+    chance = 100,
+    catch_up = false,
     action = spawn,
 })

--- a/working_villagers/spawn.lua
+++ b/working_villagers/spawn.lua
@@ -1,0 +1,44 @@
+working_villages.require("jobs/plant_collector")
+
+local herb_names = {}
+for name,_ in pairs(working_villages.herbs.names) do
+    herb_names[#herb_names + 1] = name
+end
+for name,_ in pairs(working_villages.herbs.groups) do
+    herb_names[#herb_names + 1] = name
+end
+
+local function spawn(pos, node, active_object_count, active_object_count_wider)
+    if active_object_count_wider > 2 then return end
+        local pos1 = {x=pos.x-4,y=pos.y-8,z=pos.z-4}
+        local pos2 = {x=pos.x+4,y=pos.y+1,z=pos.z+4}
+    local spawn_pos
+    for i,pos in ipairs(minetest.find_nodes_in_area_under_air(
+            pos1,pos2,{"groups:walkable"})) do
+        local above = minetest.get_node({x=pos.x,y=pos.y+2,z=pos.z})
+        local above_def = minetest.registered_nodes[above.name] 
+                if above_def and above_def.groups.walkable then
+            spawn_pos = pos
+            goto found
+        end
+    end
+    return
+
+    ::found::
+    local gender = {"working_villages:villager_male","working_villages:villager_female"}[math.random(2)]
+    local self = minetest.add_entity(spawn_pos,gender)
+    local inv = self:get_inventory()
+    local job = working_villages.job_inv:remove_item(
+        "main","working_villages:job_herbcollector") 
+    inv:set_stack("job", 1, job)
+end
+
+minetest.register_abm({
+    label = "Spawn herb collector",
+    nodenames = herb_names,
+    neighbors = "air",
+    interval = 180,
+    chance = 1000,
+    catch_up =false,
+    action = spawn,
+})


### PR DESCRIPTION
Plant gathers spawn near plants that can be gathered. The owner is set to working_villages:self_employed, and any player with a commanding_sceptre can interact with them as if the player were the owner. 

A few minor corrections also:
* Suppress a warning about access to undefined global variable modutils.
* Bugfix: server crashed under the race condition where a plant was harvested by another entity between a plant gatherer selecting it and digging it.