### PR TITLE
Fix deprecated warnings about setvelocity, etc

### DIFF
--- a/working_villagers/api.lua
+++ b/working_villagers/api.lua
@@ -213,7 +213,7 @@ end
 -- working_villages.villager.get_look_direction returns a normalized vector that is
 -- the villagers's looking direction.
 function working_villages.villager:get_look_direction()
-  local yaw = self.object:getyaw()
+  local yaw = self.object:get_yaw()
   return vector.normalize{x = -math.sin(yaw), y = 0.0, z = math.cos(yaw)}
 end
 
@@ -234,7 +234,7 @@ end
 -- working_villages.villager.set_yaw_by_direction sets the villager's yaw
 -- by a direction vector.
 function working_villages.villager:set_yaw_by_direction(direction)
-  self.object:setyaw(math.atan2(direction.z, direction.x) - math.pi / 2)
+  self.object:set_yaw(math.atan2(direction.z, direction.x) - math.pi / 2)
 end
 
 -- working_villages.villager.get_wield_item_stack returns the villager's wield item's stack.
@@ -306,7 +306,7 @@ function working_villages.villager:change_direction(destination)
   direction.y = 0
   local velocity = vector.multiply(vector.normalize(direction), 1.5)
 
-  self.object:setvelocity(velocity)
+  self.object:set_velocity(velocity)
   self:set_yaw_by_direction(direction)
 end
 
@@ -318,7 +318,7 @@ function working_villages.villager:change_direction_randomly()
     z = math.random(0, 5) * 2 - 5,
   }
   local velocity = vector.multiply(vector.normalize(direction), 1.5)
-  self.object:setvelocity(velocity)
+  self.object:set_velocity(velocity)
   self:set_yaw_by_direction(direction)
   self:set_animation(working_villages.animation_frames.WALK)
 end
@@ -401,27 +401,27 @@ function working_villages.villager:handle_liquids()
   if minetest.get_item_group(inside_node.name,"liquid") > 0 then
     -- swim
     local viscosity = minetest.registered_nodes[inside_node.name].liquid_viscosity
-    ctrl:setacceleration{x = 0, y = -self.initial_properties.weight/(100*viscosity), z = 0}
+    ctrl:set_acceleration{x = 0, y = -self.initial_properties.weight/(100*viscosity), z = 0}
   elseif minetest.registered_nodes[inside_node.name].climbable then
     --go down slowly
-    ctrl:setacceleration{x = 0, y = -0.1, z = 0}
+    ctrl:set_acceleration{x = 0, y = -0.1, z = 0}
   else
     -- fall
-    ctrl:setacceleration{x = 0, y = -self.initial_properties.weight, z = 0}
+    ctrl:set_acceleration{x = 0, y = -self.initial_properties.weight, z = 0}
   end
 end
 
 function working_villages.villager:jump()
   local ctrl = self.object
   local below_node = minetest.get_node(vector.subtract(ctrl:get_pos(),{x=0,y=1,z=0}))
-  local velocity = ctrl:getvelocity()
+  local velocity = ctrl:get_velocity()
   if below_node.name == "air" then return false end
   local jump_force = math.sqrt(self.initial_properties.weight) * 1.5
   if minetest.get_item_group(below_node.name,"liquid") > 0 then
     local viscosity = minetest.registered_nodes[below_node.name].liquid_viscosity
     jump_force = jump_force/(viscosity*100)
   end
-  ctrl:setvelocity{x = velocity.x, y = jump_force, z = velocity.z}
+  ctrl:set_velocity{x = velocity.x, y = jump_force, z = velocity.z}
 end
 
 --working_villages.villager.handle_obstacles(ignore_fence,ignore_doors)
@@ -429,7 +429,7 @@ end
 --if ignore_fence is false the villager will not jump over fences
 --if ignore_doors is false and the villager hits a door he opens it
 function working_villages.villager:handle_obstacles(ignore_fence,ignore_doors)
-  local velocity = self.object:getvelocity()
+  local velocity = self.object:get_velocity()
   local front_diff = self:get_look_direction()
   for i,v in pairs(front_diff) do
     local front_pos = vector.new(0,0,0)
@@ -549,7 +549,7 @@ function working_villages.villager:set_paused(reason)
   print("self:set_paused() is deprecated use self:set_pause() and self:set_displayed_action() instead")
   --[[
   self.pause = "resting"
-  self.object:setvelocity{x = 0, y = 0, z = 0}
+  self.object:set_velocity{x = 0, y = 0, z = 0}
   self:set_animation(working_villages.animation_frames.STAND)
   ]]
   self:set_pause(true)
@@ -894,8 +894,8 @@ function working_villages.register_villager(product_name, def)
       text = self.nametag
     }
 
-    self.object:setvelocity{x = 0, y = 0, z = 0}
-    self.object:setacceleration{x = 0, y = -self.initial_properties.weight, z = 0}
+    self.object:set_velocity{x = 0, y = 0, z = 0}
+    self.object:set_acceleration{x = 0, y = -self.initial_properties.weight, z = 0}
 
     --legacy
     if type(self.pause) == "string" then

--- a/working_villagers/async_actions.lua
+++ b/working_villagers/async_actions.lua
@@ -67,7 +67,7 @@ function working_villages.villager:go_to(pos)
 		coroutine.yield()
 	end
 	-- stop
-	self.object:setvelocity{x = 0, y = 0, z = 0}
+	self.object:set_velocity{x = 0, y = 0, z = 0}
 	self.path = nil
 	self:set_animation(working_villages.animation_frames.STAND)
 	return true
@@ -91,7 +91,7 @@ local drop_range = {x = 2, y = 10, z = 2}
 
 function working_villages.villager:dig(pos,collect_drops)
 	if func.is_protected(self, pos) then return false, fail.protected end
-	self.object:setvelocity{x = 0, y = 0, z = 0}
+	self.object:set_velocity{x = 0, y = 0, z = 0}
 	local dist = vector.subtract(pos, self.object:get_pos())
 	if vector.length(dist) > 5 then
 		self:set_animation(working_villages.animation_frames.STAND)
@@ -193,7 +193,7 @@ function working_villages.villager:place(item,pos)
 	 return false, fail.not_in_inventory
 	end
 	--set animation
-	if self.object:getvelocity().x==0 and self.object:getvelocity().z==0 then
+	if self.object:get_velocity().x==0 and self.object:get_velocity().z==0 then
 		self:set_animation(working_villages.animation_frames.MINE)
 	else
 		self:set_animation(working_villages.animation_frames.WALK_MINE)
@@ -241,7 +241,7 @@ function working_villages.villager:place(item,pos)
 		end
 	end
 	--reset animation
-	if self.object:getvelocity().x==0 and self.object:getvelocity().z==0 then
+	if self.object:get_velocity().x==0 and self.object:get_velocity().z==0 then
 		self:set_animation(working_villages.animation_frames.STAND)
 	else
 		self:set_animation(working_villages.animation_frames.WALK)
@@ -260,7 +260,7 @@ end
 
 function working_villages.villager:sleep()
 	log.action("villager %s is laying down",self.inventory_name)
-	self.object:setvelocity{x = 0, y = 0, z = 0}
+	self.object:set_velocity{x = 0, y = 0, z = 0}
 	local bed_pos = vector.new(self.pos_data.bed_pos)
 	local bed_top = func.find_adjacent_pos(bed_pos,
 		function(p) return string.find(minetest.get_node(p).name,"_top") end)

--- a/working_villagers/deprecated.lua
+++ b/working_villagers/deprecated.lua
@@ -177,7 +177,7 @@ function func.villager_state_machine_job(job_name,job_description,actions, sprop
 	local function to_search_idle(self)
 		self:set_timer(1,0)
 		self:set_timer(2,0)
-		self.object:setvelocity{x = 0, y = 0, z = 0}
+		self.object:set_velocity{x = 0, y = 0, z = 0}
 		self:set_animation(working_villages.animation_frames.STAND)
 	end
 
@@ -196,7 +196,7 @@ function func.villager_state_machine_job(job_name,job_description,actions, sprop
 	end
 	local function to_sleep(self)
 		log.action("villager %s is laying down", self.inventory_name)
-		self.object:setvelocity{x = 0, y = 0, z = 0}
+		self.object:set_velocity{x = 0, y = 0, z = 0}
 		local bed_pos=self:get_home():get_bed()
 		local bed_top = func.find_adjacent_pos(bed_pos,
 			function(p) return string.find(minetest.get_node(p).name,"_top") end)
@@ -274,15 +274,15 @@ function func.villager_state_machine_job(job_name,job_description,actions, sprop
 	end
 	--job definitions
 	local function on_start(self)
-		self.object:setacceleration{x = 0, y = -10, z = 0}
-		self.object:setvelocity{x = 0, y = 0, z = 0}
+		self.object:set_acceleration{x = 0, y = -10, z = 0}
+		self.object:set_velocity{x = 0, y = 0, z = 0}
 		self.job_state = self:get_job().states.SEARCH
 		self.time_counters = {}
 		self.path = nil
 		self:get_job().states.SEARCH.to_state(self)
 	end
 	local function on_stop(self)
-		self.object:setvelocity{x = 0, y = 0, z = 0}
+		self.object:set_velocity{x = 0, y = 0, z = 0}
 		self.job_state = nil
 		self.time_counters = nil
 		self.path = nil
@@ -290,13 +290,13 @@ function func.villager_state_machine_job(job_name,job_description,actions, sprop
 	end
 	local function on_resume(self)
 		local job = self:get_job()
-		self.object:setacceleration{x = 0, y = -10, z = 0}
-		self.object:setvelocity{x = 0, y = 0, z = 0}
+		self.object:set_acceleration{x = 0, y = -10, z = 0}
+		self.object:set_velocity{x = 0, y = 0, z = 0}
 		self.job_state = job.states.SEARCH
 		job.states.SEARCH.to_state(self)
 	end
 	local function on_pause(self)
-		self.object:setvelocity{x = 0, y = 0, z = 0}
+		self.object:set_velocity{x = 0, y = 0, z = 0}
 		self.job_state = nil
 		self:set_animation(working_villages.animation_frames.STAND)
 	end

--- a/working_villagers/jobs/follow_player.lua
+++ b/working_villagers/jobs/follow_player.lua
@@ -7,12 +7,12 @@ function follower.walk_in_direction(v,dir)
     v:jump()
   end
 
-  local velocity = v.object:getvelocity()
+  local velocity = v.object:get_velocity()
   if velocity.x==0 and velocity.y==0 then
     v:set_animation(working_villages.animation_frames.WALK)
   end
   --speed should actually be limited
-  v.object:setvelocity{x = dir.x, y = velocity.y, z = dir.z}
+  v.object:set_velocity{x = dir.x, y = velocity.y, z = dir.z}
   v:set_yaw_by_direction(dir)
 
   --if villager is stoped by obstacle, the villager must jump.
@@ -20,10 +20,10 @@ function follower.walk_in_direction(v,dir)
 end
 
 function follower.stop(v)
-  local velocity = v.object:getvelocity()
+  local velocity = v.object:get_velocity()
   if velocity.x~=0 or velocity.y~=0 then
     v:set_animation(working_villages.animation_frames.STAND)
-    v.object:setvelocity{x = 0, y = velocity.y, z = 0}
+    v.object:set_velocity{x = 0, y = velocity.y, z = 0}
   end
 end
 

--- a/working_villagers/jobs/guard.lua
+++ b/working_villagers/jobs/guard.lua
@@ -34,18 +34,18 @@ working_villages.register_job("working_villages:job_guard", {
 			local target_position = escort_target:get_pos()
 			local distance = vector.subtract(target_position, self.object:get_pos())
 
-			local velocity = self.object:getvelocity()
+			local velocity = self.object:get_velocity()
 			if vector.length(distance) < 3 then
 				if velocity.x~=0 or velocity.y~=0 then
 					self:set_animation(working_villages.animation_frames.STAND)
-					self.object:setvelocity{x = 0, y = velocity.y, z = 0}
+					self.object:set_velocity{x = 0, y = velocity.y, z = 0}
 				end
 			else
 				if velocity.x==0 and velocity.y==0 then
 					self:set_animation(working_villages.animation_frames.WALK)
 				end
 				--FIXME: don't run too fast, perhaps go_to
-				self.object:setvelocity{x = distance.x, y = velocity.y, z = distance.z}
+				self.object:set_velocity{x = distance.x, y = velocity.y, z = distance.z}
 				self:set_yaw_by_direction(distance)
 
 				--if villager is stoped by obstacle, the villager must jump.

--- a/working_villagers/villager_state.lua
+++ b/working_villagers/villager_state.lua
@@ -2,7 +2,7 @@ function working_villages.villager:set_pause(state)
   assert(type(state) == "boolean","pause state must be a boolean")
   self.pause = state
   if state then
-    self.object:setvelocity{x = 0, y = 0, z = 0}
+    self.object:set_velocity{x = 0, y = 0, z = 0}
     --perhaps check what animation we are in
     self:set_animation(working_villages.animation_frames.STAND)
   end


### PR DESCRIPTION
I was seeing a lot of this sort of warning.
WARNING[Server]: Call to deprecated function 'setvelocity', please use 'set_velocity' at ...

This commit replaces the following:
	setvelocity -> set_velocity
	getvelocity -> get_velocity
	getyaw -> get_yaw
	setyaw -> set_yaw
	setacceleration -> set_acceleration