### PR TITLE
Detect if a place failed and properly reduce the count

### DIFF
--- a/working_villagers/async_actions.lua
+++ b/working_villagers/async_actions.lua
@@ -219,13 +219,22 @@ function working_villages.villager:place(item,pos)
 		--minetest.place_node(pos, item) --loses param2
 		stack:take_item(1)
 	else
+		local before_node = minetest.get_node(pos)
+		local before_count = stack:get_count()
 		local itemdef = stack:get_definition()
 		if itemdef.on_place then
 			stack = itemdef.on_place(stack, self.object, pointed_thing)
 		elseif itemdef.type=="node" then
 			stack = minetest.item_place_node(stack, self.object, pointed_thing)
-			--minetest.set_node(pointed_thing.above, {name = itemname})
-			--minetest.place_node(pos, {name = itemname}) --Place node with the same effects that a player would cause
+		end
+		local after_node = minetest.get_node(pos)
+		-- if the node didn't change, then the callback failed
+		if before_node.name == after_node.name then
+			return false, fail.protected
+		end
+		-- if in creative mode, the callback may not reduce the stack
+		if before_count == stack:get_count() then
+			stack:take_item(1)
 		end
 	end
 	--take item


### PR DESCRIPTION
This fixes the creative mode issue and enables the ability for a higher level to reliably detect a place failure.

If creative mode is enabled, a woodcutter will place saplings forever. This fixes that.

Also, if a place fails in an on_place() function, this will detect it as a protection issue.