### PR TITLE
Log error instead of crashing the game in job_coroutines.lua

### DIFF
--- a/working_villagers/job_coroutines.lua
+++ b/working_villagers/job_coroutines.lua
@@ -39,7 +39,8 @@ function job_coroutines.resume(self,dtime)
        self:set_displayed_action(ret[3])
       end
     else
-      error("error in job_thread " .. ret[2]..": "..debug.traceback(self.job_thread))
+      -- log the error instead of crashing the server.
+      minetest.log("error", "error in job_thread " .. ret[2]..": "..debug.traceback(self.job_thread))
     end
   end
 end


### PR DESCRIPTION
fixes the root cause of many crashes that point to same line.

TL;DR

`error()` throws an exception basically and causes everything to crash. Logging the error, especially if it's not critical, seems the more sensible thing to do.


Long explanation:

at least 3 different errors all boil down to same line job_corutine.lua:42

fixes #20 amongst other things. 

A lot of other mods and even the default game assume that actions are performed by the player only and do not expect villagers to be interacting with certain nodes and entities. It is virtually impossible to debug each and every one of them or add extra code in this mod to account for it. For example #39 adds further logic to remember failed nodes but if every node fails, we run the risk of out of memory issues as the list of failed nodes grows and grows.

While it seems tempting to throw an error to force the user to report the issue, it just makes the average user think that this mod is broken and they will more likely just uninstall it.

